### PR TITLE
死期による分岐の正常化とはじめから選択時のリセットの修正

### DIFF
--- a/GameDirector.gd
+++ b/GameDirector.gd
@@ -32,8 +32,15 @@ func _setup_chapter_logic(id: String):
 		Global.is_death_timer_active = false
 	
 	if id == "day_7":
-		Global.kokorone_death_seconds = 239.0
 		Global.is_timer_active = true
+		
+		# --- 追加：ココロネの関連タイマー変数を全て239秒（約4分）に同期する ---
+		Global.kokorone_death_seconds = 20.0
+		Global.death_timers["Kokorone"] = 20.0
+		
+		# UI表示用の新しいデータ構造の方も上書きする（これが画面に反映される）
+		if Global.death_data.has("Kokorone"):
+			Global.death_data["Kokorone"]["red"] = 20.0
 
 # --- 2. 進行管理 ---
 func play_current_event():
@@ -81,9 +88,10 @@ func _finish_chapter():
 		"Flame": Global.flame_count += 1
 		"Soul": Global.soul_count += 1
 	
-	if not Global.is_part2 and current_data.chapter_id != "prologue":
+	# "day_7" の終わりはまだ選択肢（続き）があるので、1日経過の処理を除外する
+	if not Global.is_part2 and current_data.chapter_id != "prologue" and current_data.chapter_id != "day_7":
 		Global.advance_all_timers(Global.SECONDS_PER_DAY)
-
+		
 	# 次の行動の判定
 	match current_data.next_action:
 		ScenarioData.NextAction.AUTO_NEXT:
@@ -94,16 +102,22 @@ func _finish_chapter():
 			
 		ScenarioData.NextAction.DETERMINE_END:
 			if Global.current_chapter_id == "day_7":
-				Global.is_timer_active = false 
-				if Global.kokorone_death_seconds > 0:
-					stage.show_choices(["運命に抗う（通常エンドへ）", "諦める（バッドエンドへ）"])
-				else:
-					stage.show_choices(["……（手遅れだった、バッドエンドへ）"])
-			else:
-				# 第2部のエンディング判定
-				Global.current_chapter_id = Global.evaluate_part2_ending()
-				Global.current_line_index = 0
-				get_tree().reload_current_scene()
+				
+				# ココロネの red (歪み死期) の現在値を取得
+				# ※ Global.get_current_death_time は、red/whiteのうち
+				#   その時表示されている（または優先される）方を返す想定です。
+				var current_red_time = Global.get_current_death_time("Kokorone")
+				
+				var choice_texts = ["運命に抗う（通常エンドへ）", "諦める（バッドエンドへ）"]
+				var disabled_list = []
+				
+				# redの数値が0以下なら、0番目のボタン（運命に抗う）を無効化リストに入れる
+				if current_red_time <= 0:
+					disabled_list.append(0)
+				
+				# 拡張した show_choices を呼び出す
+				stage.show_choices(choice_texts, disabled_list)
+				
 			
 		ScenarioData.NextAction.OPEN_MAP:
 			get_tree().change_scene_to_file("res://map_selection.tscn")

--- a/Global.gd
+++ b/Global.gd
@@ -60,13 +60,14 @@ var death_data = {
 var pending_death_event: String = ""
 # --- 便利関数（計算・判定用） ---
 
-# 現在表示すべき「死期」の数値を返す（赤優先）
+# 現在表示すべき「死期」の数値を返す
 func get_current_death_time(char_id: String) -> float:
 	if not death_data.has(char_id): return 0.0
 	var data = death_data[char_id]
-	# 赤(red)が設定されていればそれを、なければ白(white)を返す
-	return data["red"] if data["red"] > 0 else data["white"]
-
+	
+	# 赤(red)が未設定(-1.0)でなければ赤を、未設定なら白(white)を返す
+	return data["red"] if data["red"] != -1.0 else data["white"]
+	
 # キャラクターを発見（マウスオーバー）した時に呼ぶ
 func discover_death_time(char_id: String):
 	if death_data.has(char_id):
@@ -306,10 +307,37 @@ func reset_game_progress():
 	current_chapter_id = "prologue"
 	current_line_index = 0
 	flags = {}
+	
+	# --- 死期変数を初期値にリセット ---
+	player_death_seconds = 2587670064.0
+	kokorone_death_seconds = 582252.0  # 約6日18時間
+	homura_death_seconds = 600000.0
+	rei_death_seconds = 600000.0
+	
+	# --- 判定に使っている死期データ(death_data)を空にする ---
+	# --- 判定に使っている死期データ(death_data)を初期状態にリセットする ---
+	death_data = {
+		"Player":   {"white": 2587670064.0, "red": -1.0, "discovered": true, "is_dead": false, "last_seen_white": 2587670064.0, "last_seen_red": -1.0},
+		"Kokorone": {"white": 1356048000.0, "red": 529200.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
+		"Homura":   {"white": 600000.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
+		"Rei":      {"white": 600000.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0}
+	}
+	
+	# --- 生存フラグ・タイマー稼働状態をリセット ---
+	is_kokorone_dead = false
+	is_homura_dead = false
+	is_rei_dead = false
+	
+	is_timer_active = false
+	is_death_timer_active = false
+	
+	# ※その他、BGMや背景などの演出用変数もあればここでリセット
+	current_bg_path = ""
+	print("ゲーム進行状況を完全にリセットしました。")
+	
 	is_part2 = false
 	current_day = 1
 	current_period = 0
-	is_timer_active = false
 	# 他の変数も初期値にリセット
 	
 	

--- a/main_game.gd
+++ b/main_game.gd
@@ -24,6 +24,8 @@ var is_skipping: bool = false
 @onready var pause_menu = $PauseMenu 
 @onready var menu_button = $SystemButtons/MenuButton # 追加したボタン
 
+var day7_resist_button: Button = null
+
 # --- 3. 初期化処理 ---
 func _ready():
 	message_window.message_finished.connect(_on_message_window_finished)
@@ -158,14 +160,27 @@ func _update_button_visuals():
 	skip_button.modulate = Color.ORANGE if is_skipping else Color.WHITE
 
 # --- 8. 選択肢・特殊演出 ---
-func show_choices(choices: Array):
+func show_choices(choices: Array, disabled_indices: Array = []):
+	day7_resist_button = null # 初期化
 	for child in choice_container.get_children(): child.queue_free()
+	
 	for i in range(choices.size()):
 		var btn = Button.new()
 		btn.text = choices[i]
 		btn.custom_minimum_size = Vector2(200, 50)
+		
+		# ---「運命に抗う」ボタンを後で監視するために変数に入れておく---
+		if choices[i].contains("運命に抗う"):
+			day7_resist_button = btn
+		
+		# --- 無効化の判定 ---
+		if i in disabled_indices:
+			btn.disabled = true # ボタンをグレーアウトして押せなくする
+			btn.focus_mode = Control.FOCUS_NONE # 選択もできないようにする
+		
 		btn.pressed.connect(_on_choice_selected.bind(i))
 		choice_container.add_child(btn)
+	
 	choice_container.show()
 
 func _on_choice_selected(index: int):
@@ -190,3 +205,15 @@ func _on_menu_button_pressed() -> void:
 	
 	# ポーズメニュー内の toggle_pause を実行
 	pause_menu.toggle_pause()
+	
+# --- _process 関数を追加（または既存のものに追記） ---
+func _process(_delta):
+	# 監視中のボタンがあり、かつまだ無効化されていない場合
+	if day7_resist_button and not day7_resist_button.disabled:
+		# リアルタイムで死期をチェック
+		if Global.get_current_death_time("Kokorone") <= 0:
+			day7_resist_button.disabled = true
+			day7_resist_button.focus_mode = Control.FOCUS_NONE
+			# ついでにタイマーをここで止めてもいいかもしれません
+			Global.is_timer_active = false
+			print("時間切れにより選択肢が封鎖されました")

--- a/project.godot
+++ b/project.godot
@@ -21,7 +21,7 @@ Global="*res://Global.gd"
 
 [editor]
 
-movie_writer/movie_file="D:/godotdebuc/AddMenuButton.avi"
+movie_writer/movie_file="D:/godotdebuc/refleshDeathtime.avi"
 
 [filesystem]
 

--- a/timer_label.gd
+++ b/timer_label.gd
@@ -222,12 +222,16 @@ func perform_glitch_effect():
 	
 # --- 状態に応じた数字の更新（歪み vs 真実） ---
 func update_display_by_state():
+	# 安全策: target_char_id が設定されていない、またはデータが存在しない場合は処理を中断
+	if target_char_id == "" or not Global.death_data.has(target_char_id):
+		return
+
 	var data = Global.death_data[target_char_id]
 	if is_revealed:
 		update_timer_images(int(data["white"]), false) # 琥珀色
 	else:
 		update_timer_images(int(data["red"]), true)   # 赤色
-
+		
 # --- マウスから逃げる（座標計算の修正） ---
 func handle_repulsion():
 	var mouse_pos = get_local_mouse_position() - container.position


### PR DESCRIPTION
死期におけるフラグ管理の修正
＊死期(red)における減少が0になったとき、運命に抗う選択肢(happyend)への道がグレーアウトするように修正しました。

＊シナリオ「day_7」終了時選択肢が出た瞬間に、1日分死期が縮まるのを修正しました。これで選択肢が出た瞬間に死期(red)がすでに0になっているというのを回避しようとしました。しかし、以下記載に変更。
＊＊7章開始時に死期(red)の数値を決めることにしました。現在デバックしやすくするため、約４分(240秒)の所を20秒にしています。

はじめから選択時、リセット関数を更新
＊死期時間の更新をして、バッドエンド後に初めからを押すと、減少した死期を引き継ぐのを防止しました。