### PR TITLE
prologue死期

### DIFF
--- a/GameDirector.gd
+++ b/GameDirector.gd
@@ -24,13 +24,12 @@ func start_scenario(id: String):
 
 # 章ごとの特殊なロジック設定
 func _setup_chapter_logic(id: String):
-	if id != "prologue":
-		Global.prepare_death_timer_for_next_day()
-		Global.is_death_timer_active = true
-	else:
-		Global.current_death_floor = Global.player_death_seconds - Global.SECONDS_PER_DAY
-		Global.is_death_timer_active = false
+	# プロローグかどうかに関わらず、タイマーの計算自体は動かす
+	Global.is_death_timer_active = true
 	
+	if id != "prologue":
+		Global.current_death_floor = Global.player_death_seconds - Global.SECONDS_PER_DAY
+		
 	if id == "day_7":
 		Global.is_timer_active = true
 		

--- a/Global.gd
+++ b/Global.gd
@@ -33,6 +33,7 @@ var cat_death_seconds: float = 3200.0
 var is_kokorone_dead: bool = false
 var is_homura_dead: bool = false
 var is_rei_dead: bool = false
+var is_cat_dead: bool = false
 
 # --- 4. システム設定・定数 ---
 var system_data = {
@@ -54,9 +55,9 @@ const SECONDS_PER_PERIOD = 43200.0 # 12時間（第2部用）
 var death_data = {
 	"Player":   {"white": 2587670064.0, "red": -1.0, "discovered": true, "is_dead": false, "last_seen_white": 2587670064.0, "last_seen_red": -1.0},
 	"Kokorone": {"white": 1356048000.0, "red": 529200.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
-	"Homura":   {"white": 600000.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
+	"Homura":   {"white": 600000.0,     "red": 300000.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
 	"Rei":      {"white": 600000.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
-	"cat":      {"white": 3200.0,     "red": 3200.0, "discovered": false, "is_dead": false, "last_seen_white": 3200.0, "last_seen_red": -1.0}
+	"Cat":      {"white": 3200.0,     "red": 3200.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0}
 }
 # 次の遷移時に実行すべき死亡イベント（キャラIDを入れる）
 var pending_death_event: String = ""
@@ -85,6 +86,9 @@ func record_observed_time(char_id: String):
 		
 # 死期を減らす（時間経過）
 func advance_death_time(char_id: String, seconds: float):
+	# 【追加】プロローグ中、プレイヤーの死期だけは減らさない
+	if current_chapter_id == "prologue" and char_id == "Player": return
+	
 	if not death_data.has(char_id) or death_data[char_id]["is_dead"]: return
 	
 	var data = death_data[char_id]
@@ -179,6 +183,7 @@ func update_heroine_timers(delta):
 	if not is_kokorone_dead: death_timers["Kokorone"] = max(0, death_timers["Kokorone"] - delta)
 	if not is_homura_dead: death_timers["Homura"] = max(0, death_timers["Homura"] - delta)
 	if not is_rei_dead: death_timers["Rei"] = max(0, death_timers["Rei"] - delta)
+	if not is_rei_dead: death_timers["Cat"] = max(0, death_timers["Cat"] - delta)
 
 func add_flag(flag_name: String):
 	if flag_name == "": return
@@ -322,15 +327,16 @@ func reset_game_progress():
 	death_data = {
 		"Player":   {"white": 2587670064.0, "red": -1.0, "discovered": true, "is_dead": false, "last_seen_white": 2587670064.0, "last_seen_red": -1.0},
 		"Kokorone": {"white": 1356048000.0, "red": 529200.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
-		"Homura":   {"white": 600000.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
+		"Homura":   {"white": 600000.0,     "red": 300000.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
 		"Rei":      {"white": 600000.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0},
-		"Cat":      {"white": 3200.0,     "red": -1.0, "discovered": false, "is_dead": false, "last_seen_white": 3200.0, "last_seen_red": -1.0}
+		"Cat":      {"white": 3200.0,     "red": 3200.0, "discovered": false, "is_dead": false, "last_seen_white": -1.0, "last_seen_red": -1.0}
 	}
 	
 	# --- 生存フラグ・タイマー稼働状態をリセット ---
 	is_kokorone_dead = false
 	is_homura_dead = false
 	is_rei_dead = false
+	is_cat_dead = false
 	
 	is_timer_active = false
 	is_death_timer_active = false


### PR DESCRIPTION
GameDirector.gd の _setup_chapter_logic 関数内に、プロローグの時だけ「死期システムのエンジン自体」を止めてしまうコードがありました。これにより、プロローグ時死期が減らないという状態に陥りました。このシステムはもともと、プロローグが主人公の回想シーンのため、死期が止まるように仕組んでいたものでした。
なので、今回はGameDirector.gdとGlobal.gdに変更を加えてます。

*解決法としてエンジン(is_death_timer_active)は動かしたまま、プレイヤーだけ亢進対象から外す。

猫の寿命は何となく3200秒(約53分)にしています。今後は選択肢を押した後、少しシナリオの表記が変わってから合流という形にしたいです。また、選択肢押した後に死期が減少するようにして時間の経過を表したいところです。