### PR TITLE
選択肢分岐と死期予測表示

### DIFF
--- a/GameDirector.gd
+++ b/GameDirector.gd
@@ -10,16 +10,33 @@ var current_index: int = 0
 var is_changing_scene: bool = false # 二重処理防止フラグ
 # --- 1. シナリオ開始 ---
 func start_scenario(id: String):
+	# 1. データのロード
 	current_data = Global.get_scenario_resource(id)
-	if not current_data:
-		printerr("シナリオが見つかりません: ", id)
-		get_tree().change_scene_to_file("res://title_screen.tscn")
+	if current_data == null:
+		printerr("シナリオが見らつかりません: ", id)
 		return
-
-	# 章ごとの初期設定（元の main_game の _ready からの引っ越し）
+	
+	# ★追加: Global側の現在IDも更新しておく（セーブ時などに重要）
+	Global.current_chapter_id = id
+	
+	# 2. 下限値の更新
+	Global.current_death_floor = current_data.chapter_death_floor
+	
+	# 3. インデックスのリセット
+	# 新しくシナリオを始める時は常に 0 から。
+	# ただし、ロード直後だけは Global の値を引き継ぎたいので条件分岐させます。
+	if Global.is_loading_process:
+		current_index = Global.current_line_index
+		# ロード処理が終わったらフラグを下ろす（Global.gd側でやっていれば不要）
+		# Global.is_loading_process = false 
+	else:
+		current_index = 0
+		Global.current_line_index = 0 # Global側もリセット
+	
+	# 4. 章ごとの特殊ロジック
 	_setup_chapter_logic(id)
 	
-	current_index = Global.current_line_index
+	# 5. 再生開始
 	play_current_event()
 
 # 章ごとの特殊なロジック設定
@@ -59,21 +76,31 @@ func next_line():
 
 # --- 3. 選択肢や場所の「判定」 ---
 
-# プレイヤーが選択肢を選んだ時の処理（main_gameから呼ばれる）
+# 選択肢が選ばれた時
 func handle_choice(index: int):
-	if Global.current_chapter_id == "day_7":
-		if index == 0: 
-			Global.current_chapter_id = "happy_end1"
-		else: 
-			Global.current_chapter_id = "bad_end1"
-		Global.current_line_index = 0
-		get_tree().reload_current_scene()
-		return
-		
-	# day_7 以外の章（今回のプロローグなど）で選択肢が出た場合
-	# どっちを選んでもシナリオは合流するので、単に次の行へ進める
-	next_line()
+	# 現在のイベントデータを取得（変数名はそちらの環境に合わせてください）
+	var current_event = current_data.events[current_index]
 	
+	# 1. 選んだ選択肢による死期の増減を適用（プレイヤー対象の場合）
+	# ※target_char_idに適用するようにも作れますが、一旦メインの寿命と仮定
+	if current_event.choice_time_modifiers.size() > index:
+		var mod = current_event.choice_time_modifiers[index]
+		if mod != 0.0:
+			# マイナスの値が設定されていれば寿命が減る
+			Global.player_death_seconds += mod 
+			# 下限を下回らないようにする
+			Global.player_death_seconds = max(Global.current_death_floor, Global.player_death_seconds)
+
+	# 2. 分岐先が指定されていれば、そのシナリオIDへジャンプ！
+	if current_event.choice_next_scenario_ids.size() > index:
+		var next_id = current_event.choice_next_scenario_ids[index]
+		if next_id != "":
+			print("シナリオ分岐: ", next_id, " へジャンプします")
+			start_scenario(next_id)
+			return # ジャンプしたのでここで終了
+			
+	# 3. 分岐先がない（空文字）場合は、単純に合流して次の行へ
+	next_line()
 # マップで場所を選んだ時の処理
 func handle_location_selected(_location_id: String):
 	Global.advance_all_timers(Global.SECONDS_PER_PERIOD)

--- a/Global.gd
+++ b/Global.gd
@@ -86,18 +86,26 @@ func record_observed_time(char_id: String):
 		
 # 死期を減らす（時間経過）
 func advance_death_time(char_id: String, seconds: float):
-	# 【追加】プロローグ中、プレイヤーの死期だけは減らさない
+	# プロローグ中、プレイヤーの死期だけは減らさない
 	if current_chapter_id == "prologue" and char_id == "Player": return
-	
 	if not death_data.has(char_id) or death_data[char_id]["is_dead"]: return
 	
 	var data = death_data[char_id]
 	
-	# 赤の状態に関わらず、白(本来の死期)は常に時間を進める
-	data["white"] = max(0, data["white"] - seconds)
+# 減少処理
+	var new_white = data["white"] - seconds
+	var new_red = data["red"] - seconds
 	
-	if data["red"] > 0:
-		data["red"] = max(0, data["red"] - seconds)
+	# ★ プレイヤーの死期なら下限(current_death_floor)で止める
+	if char_id == "Player":
+		data["white"] = max(current_death_floor, new_white)
+		if data["red"] > 0:
+			data["red"] = max(current_death_floor, new_red)
+	else:
+		# ヒロインたちは通常通り0が下限
+		data["white"] = max(0.0, new_white)
+		if data["red"] > 0:
+			data["red"] = max(0.0, new_red)
 	
 	# 0になったら死亡フラグを立てる
 	if get_current_death_time(char_id) <= 0:
@@ -112,6 +120,9 @@ func advance_all_timers(seconds: float):
 # シナリオのリソース登録
 var scenario_registry = {
 	"prologue": "res://scenarios/prologue.tres",
+	"prologue_cat_leaved1_root" :"res://scenarios/prologue_cat_leaved1_root.tres",
+	"prologue_cat_saved1_root" :"res://scenarios/prologue_cat_saved1_root.tres",
+	"prologue2": "res://scenarios/prologue2.tres",
 	"day_1": "res://scenarios/day_1.tres",
 	"day_2": "res://scenarios/day_2.tres",
 	"day_3": "res://scenarios/day_3.tres",
@@ -183,7 +194,7 @@ func update_heroine_timers(delta):
 	if not is_kokorone_dead: death_timers["Kokorone"] = max(0, death_timers["Kokorone"] - delta)
 	if not is_homura_dead: death_timers["Homura"] = max(0, death_timers["Homura"] - delta)
 	if not is_rei_dead: death_timers["Rei"] = max(0, death_timers["Rei"] - delta)
-	if not is_rei_dead: death_timers["Cat"] = max(0, death_timers["Cat"] - delta)
+	if not is_cat_dead: death_timers["Cat"] = max(0, death_timers["Cat"] - delta)
 
 func add_flag(flag_name: String):
 	if flag_name == "": return

--- a/dialogue_event.gd
+++ b/dialogue_event.gd
@@ -31,11 +31,23 @@ enum CharID { NONE, KOKORONE, HOMURA, REI, CAT }
 @export var clear_other_slots: bool = true # デフォルトは「消す（今まで通り）」
 
 @export_group("System Commands")
-# trueにすると、このセリフの時にクリック進行を止め、対象キャラへのマウスオーバーを待つ
+
+## trueにすると、このセリフの時にクリック進行を止め、対象キャラへのマウスオーバーを待つ
 @export var require_hover_tutorial: bool = false
-# チュートリアルや選択肢で対象とするキャラID (例: "Cat")
+
+## チュートリアルや選択肢で対象とするキャラID (例: "Cat")
 @export var target_char_id: String = ""
 
-@export_group("Choices")
-# 選択肢のテキスト。空配列なら通常のクリック進行、テキストが入っていれば選択肢を表示する
+@export_group("Choices & Branching")
+
+## 選択肢として表示されるテキストのリスト
 @export var choices: Array[String] = []
+
+## 分岐先シナリオID（選択肢の数と合わせる。空文字ならそのまま次の行へ）
+@export var choice_next_scenario_ids: Array[String] = []
+
+## 各選択肢を選んだ時の死期増減（秒）。マイナスなら死期が縮む。
+@export var choice_time_modifiers: Array[float] = [] 
+
+## 選択肢ボタンでの死期表示タイプ　0:Auto, 1:White, 2:Red 
+@export var choice_time_display_types: Array[int] = []

--- a/main_game.gd
+++ b/main_game.gd
@@ -28,7 +28,8 @@ var day7_resist_button: Button = null
 
 var is_waiting_for_hover: bool = false # ホバー待ち状態のフラグ
 var hover_target_id: String = ""       # 待っている対象のキャラID
-var active_choice_labels: Array = []   # 選択肢の死期更新用
+# active_choice_labels を単なるラベル配列から、辞書の配列に変更して詳細なデータを保持させます
+var active_choice_data: Array[Dictionary] = []
 
 # チュートリアル用のメッセージラベルを動的に作る（シーンに直接配置してもOKです）
 var tutorial_label: Label
@@ -197,8 +198,12 @@ func _update_button_visuals():
 # --- 8. 選択肢・特殊演出 ---
 func show_choices(choices: Array, disabled_indices: Array = [], target_id: String = ""):
 	day7_resist_button = null 
-	active_choice_labels.clear() # リセット
+	active_choice_data.clear() # リセット
 	hover_target_id = target_id  # _processで更新するために保存
+	
+	
+	# ★現在実行中のイベントを取得（ディレクターから）
+	var current_event = director.current_data.events[director.current_index]
 	
 	for child in choice_container.get_children(): child.queue_free()
 	
@@ -217,9 +222,24 @@ func show_choices(choices: Array, disabled_indices: Array = [], target_id: Strin
 			# 右下にアンカーを設定
 			time_label.set_anchors_preset(Control.PRESET_BOTTOM_RIGHT)
 			time_label.position = Vector2(-10, -30) # 少し内側にずらす
-			
 			btn.add_child(time_label)
-			active_choice_labels.append(time_label) # リアルタイム更新用リストに追加
+			
+			# ★_processで計算できるように、ラベルと一緒に増減値と表示タイプを保存
+			# ★ここを修正：配列からその選択肢専用の表示タイプを取得する
+			var modifier = 0.0
+			if current_event.choice_time_modifiers.size() > i:
+				modifier = current_event.choice_time_modifiers[i]
+				
+			# 追加：表示タイプを配列から取得（足りなければデフォルト 0:Auto）
+			var display_type = 0
+			if current_event.choice_time_display_types.size() > i:
+				display_type = current_event.choice_time_display_types[i]
+				
+			active_choice_data.append({
+				"label": time_label,
+				"modifier": modifier,
+				"display_type": display_type # ここに個別の設定が入る！
+			})
 			
 		# ---「運命に抗う」ボタンを後で監視するために変数に入れておく---
 		if choices[i].contains("運命に抗う"):
@@ -278,10 +298,42 @@ func _process(_delta):
 			# 0.5秒くらい余韻を残してから自動で次の行へ進む
 			get_tree().create_timer(0.5).timeout.connect(advance_line)
 			
-	# ★選択肢ボタンの死期リアルタイム更新
-	if active_choice_labels.size() > 0 and hover_target_id != "":
-		var current_time = Global.get_current_death_time(hover_target_id)
-		var time_str = Global.format_death_time(current_time)
-		for label in active_choice_labels:
-			if is_instance_valid(label):
-				label.text = "死期: " + time_str
+# ★選択肢ボタンの死期リアルタイム更新（予測計算対応）
+	if active_choice_data.size() > 0 and hover_target_id != "":
+		for data in active_choice_data:
+			if is_instance_valid(data["label"]):
+				# 1. 基準となる時間を決定 (Auto / White / Red)
+				var base_time = 0.0
+				if data["display_type"] == 1: # White強制
+					base_time = Global.death_data[hover_target_id]["white"]
+				elif data["display_type"] == 2: # Red強制
+					base_time = Global.death_data[hover_target_id]["red"]
+					if base_time == -1.0: base_time = Global.death_data[hover_target_id]["white"]
+				else: # Auto (デフォルト)
+					base_time = Global.get_current_death_time(hover_target_id)
+				
+				# 2. 増減予測の計算
+				var predicted_time = base_time + data["modifier"]
+				
+				# プレイヤーなら下限を考慮して予測
+				if hover_target_id == "Player":
+					predicted_time = max(Global.current_death_floor, predicted_time)
+				else:
+					predicted_time = max(0.0, predicted_time)
+
+				# 3. テキストの構築
+				var time_str = Global.format_death_time(base_time)
+				if data["modifier"] != 0.0:
+					var predicted_str = Global.format_death_time(predicted_time)
+					data["label"].text = "死期: %s\n ⇒ %s" % [time_str, predicted_str]
+				else:
+					data["label"].text = "死期: " + time_str
+
+				# ★ここから色指定：Display Type に基づいてラベルの色を変える
+				match data["display_type"]:
+					1: # White（真実）
+						data["label"].add_theme_color_override("font_color", Color.CYAN) # 鮮やかな水色
+					2: # Red（歪み）
+						data["label"].add_theme_color_override("font_color", Color(1, 0.3, 0.3)) # 警告の赤
+					_: # Auto または 0
+						data["label"].add_theme_color_override("font_color", Color.WHITE) # 通常の白

--- a/project.godot
+++ b/project.godot
@@ -21,7 +21,7 @@ Global="*res://Global.gd"
 
 [editor]
 
-movie_writer/movie_file="D:/godotdebuc/prologue.avi"
+movie_writer/movie_file="D:/godotdebuc/ScinarioDivide.avi"
 
 [filesystem]
 

--- a/scenario_date.gd
+++ b/scenario_date.gd
@@ -24,3 +24,7 @@ enum NextAction {
 @export var reward_flag: String = ""          # 読み終わった時に貰えるフラグ（例: "心その1"）
 
 @export_enum("None", "Heart", "Flame", "Soul") var reward_type: String = "None"
+
+@export_group("Death Time Limits")
+# このシナリオ（または章）での死期の下限値（秒）。これ以上は減らない。
+@export var chapter_death_floor: float = 0.0

--- a/scenarios/prologue.tres
+++ b/scenarios/prologue.tres
@@ -1,4 +1,4 @@
-[gd_resource type="Resource" script_class="ScenarioData" load_steps=35 format=3 uid="uid://bxlid8u80h413"]
+[gd_resource type="Resource" script_class="ScenarioData" load_steps=20 format=3 uid="uid://bxlid8u80h413"]
 
 [ext_resource type="Texture2D" uid="uid://2bsifjo7yiq0" path="res://images/ステグラと星空.jpg" id="1_4mfdp"]
 [ext_resource type="Script" uid="uid://cl3bhx8qa8d5x" path="res://dialogue_event.gd" id="1_phd66"]
@@ -6,8 +6,6 @@
 [ext_resource type="AudioStream" uid="uid://dpxbbwvug6m60" path="res://BGM/プロローグ.mp3" id="2_l5nuy"]
 [ext_resource type="Texture2D" uid="uid://sugcybn04qn2" path="res://images/路地裏3.jpg" id="4_bs7l3"]
 [ext_resource type="Texture2D" uid="uid://vycniucbdjsr" path="res://立ち絵/猫立ち絵.png" id="5_fh20x"]
-[ext_resource type="Texture2D" uid="uid://p6vktkcypyyd" path="res://images/路地裏猫.png" id="6_fh20x"]
-[ext_resource type="Texture2D" uid="uid://b4nu5so7vgn04" path="res://立ち絵/無.png" id="7_4gooj"]
 
 [sub_resource type="Resource" id="Resource_8x785"]
 script = ExtResource("1_phd66")
@@ -90,101 +88,15 @@ char_id = 4
 text = "花瓶が落ちてきそうだ。"
 character_sprite = ExtResource("5_fh20x")
 target_char_id = "Cat"
-choices = Array[String](["放置する", "猫を守る"])
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_h26x6"]
-script = ExtResource("1_phd66")
-text = "花瓶が落ちてきた。
-猫は無事だった。"
-shake_screen = true
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_eh8fi"]
-script = ExtResource("1_phd66")
-char_id = 4
-text = "車が急発進しそうだ。"
-target_char_id = "Cat"
-choices = Array[String](["放置する。", "猫を守る。"])
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_0hyci"]
-script = ExtResource("1_phd66")
-char_id = 4
-text = "車がエンジンをたてて走り出した。
-猫は無事だった。"
-character_sprite = ExtResource("5_fh20x")
-shake_screen = true
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_eumky"]
-script = ExtResource("1_phd66")
-char_id = 4
-text = "怪しい男がいる。
-手元が光っている。
-どうする？"
-character_sprite = ExtResource("5_fh20x")
-target_char_id = "Cat"
-choices = Array[String](["放置する。", "猫を守る。"])
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_23kif"]
-script = ExtResource("1_phd66")
-char_id = 4
-text = "男は魚をエサにして猫を釣ろうとしていただけだった。
-猫は無事だった。"
-character_sprite = ExtResource("5_fh20x")
-shake_screen = true
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_0dons"]
-script = ExtResource("1_phd66")
-text = "真夜中、静まった裏路地、くぼみの隙間で丸くなり、それから重い瞼が開くことも、一声鳴くこともなく、猫の頭上から数字が消えた。"
-character_sprite = ExtResource("7_4gooj")
-background = ExtResource("6_fh20x")
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_ym0hg"]
-script = ExtResource("1_phd66")
-text = "その場を藍色の闇が静寂を支配し、藍色の月がにやにやと笑うように淡く光っていた。"
-background = ExtResource("6_fh20x")
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_vkfql"]
-script = ExtResource("1_phd66")
-text = "死からは逃げられない。"
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_pvnh8"]
-script = ExtResource("1_phd66")
-text = "どんな過程をたどろうとも夜は等しく降りてくるのだと。"
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_blm8q"]
-script = ExtResource("1_phd66")
-text = "そのときから自分にとって死の数字は隣人になった。"
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_utxy7"]
-script = ExtResource("1_phd66")
-text = "夜遅く帰宅して親にこっぴどく叱られた。泣かれて怒られて抱きしめられ、そんな親の姿は初めてで、自分の身体が軋みに耐えかね悲鳴をあげる中、親の頭上には長生きの数字が記載されていた。ひどく安心してしまった。"
-background = ExtResource("1_4mfdp")
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_wsape"]
-script = ExtResource("1_phd66")
-text = "自分の頭の上を鏡で見て、親不孝者にはならないことを何度も確認したのは……恥ずかしいかも。"
-metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
-
-[sub_resource type="Resource" id="Resource_d3kfn"]
-script = ExtResource("1_phd66")
-text = "今までの話は俺が中学生までの過去話だ。"
+choices = Array[String](["猫を放置する", "花瓶から守る"])
+choice_next_scenario_ids = Array[String](["prologue_cat_leaved1_root", "prologue_cat_saved1_root"])
+choice_time_modifiers = Array[float]([-12.0, 12.0])
+choice_time_display_types = Array[int]([2, 2])
 metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
 
 [resource]
 script = ExtResource("2_4mfdp")
 chapter_id = "prologue"
 chapter_title = "プロローグ"
-events = Array[ExtResource("1_phd66")]([SubResource("Resource_8x785"), SubResource("Resource_l5nuy"), SubResource("Resource_bs7l3"), SubResource("Resource_4gooj"), SubResource("Resource_igjyp"), SubResource("Resource_l0lse"), SubResource("Resource_fmsum"), SubResource("Resource_0xtgi"), SubResource("Resource_8kqiv"), SubResource("Resource_1rey7"), SubResource("Resource_fh20x"), SubResource("Resource_gyt3u"), SubResource("Resource_h26x6"), SubResource("Resource_eh8fi"), SubResource("Resource_0hyci"), SubResource("Resource_eumky"), SubResource("Resource_23kif"), SubResource("Resource_0dons"), SubResource("Resource_ym0hg"), SubResource("Resource_vkfql"), SubResource("Resource_pvnh8"), SubResource("Resource_blm8q"), SubResource("Resource_utxy7"), SubResource("Resource_wsape"), SubResource("Resource_d3kfn")])
-next_chapter_id = "day_1"
+events = Array[ExtResource("1_phd66")]([SubResource("Resource_8x785"), SubResource("Resource_l5nuy"), SubResource("Resource_bs7l3"), SubResource("Resource_4gooj"), SubResource("Resource_igjyp"), SubResource("Resource_l0lse"), SubResource("Resource_fmsum"), SubResource("Resource_0xtgi"), SubResource("Resource_8kqiv"), SubResource("Resource_1rey7"), SubResource("Resource_fh20x"), SubResource("Resource_gyt3u")])
 metadata/_custom_type_script = "uid://nsjru0u7n42l"

--- a/scenarios/prologue2.tres
+++ b/scenarios/prologue2.tres
@@ -1,0 +1,18 @@
+[gd_resource type="Resource" script_class="ScenarioData" load_steps=5 format=3 uid="uid://b023leqp8djl8"]
+
+[ext_resource type="Script" uid="uid://cl3bhx8qa8d5x" path="res://dialogue_event.gd" id="1_5vdv1"]
+[ext_resource type="Script" uid="uid://nsjru0u7n42l" path="res://scenario_date.gd" id="2_bl5d5"]
+[ext_resource type="Texture2D" uid="uid://0aosbm30laop" path="res://images/道路.png" id="2_e4c5x"]
+
+[sub_resource type="Resource" id="Resource_bne1n"]
+script = ExtResource("1_5vdv1")
+text = "分岐後合流の確認"
+background = ExtResource("2_e4c5x")
+metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
+
+[resource]
+script = ExtResource("2_bl5d5")
+chapter_id = "prologue"
+events = Array[ExtResource("1_5vdv1")]([SubResource("Resource_bne1n")])
+next_chapter_id = "day_1"
+metadata/_custom_type_script = "uid://nsjru0u7n42l"

--- a/scenarios/prologue_cat_leaved1_root.tres
+++ b/scenarios/prologue_cat_leaved1_root.tres
@@ -1,0 +1,26 @@
+[gd_resource type="Resource" script_class="ScenarioData" load_steps=6 format=3 uid="uid://c81orm0bkwxfd"]
+
+[ext_resource type="Script" uid="uid://cl3bhx8qa8d5x" path="res://dialogue_event.gd" id="1_lrbby"]
+[ext_resource type="Script" uid="uid://nsjru0u7n42l" path="res://scenario_date.gd" id="2_21i66"]
+[ext_resource type="Texture2D" uid="uid://vycniucbdjsr" path="res://立ち絵/猫立ち絵.png" id="2_e510h"]
+
+[sub_resource type="Resource" id="Resource_foagb"]
+script = ExtResource("1_lrbby")
+char_id = 4
+text = "猫は無事だった。花瓶は猫のそばに落ちたが、
+破片で傷を負わなかったようだ。"
+character_sprite = ExtResource("2_e510h")
+shake_screen = true
+metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
+
+[sub_resource type="Resource" id="Resource_21i66"]
+script = ExtResource("1_lrbby")
+text = "猫の後を追い続けよう。"
+metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
+
+[resource]
+script = ExtResource("2_21i66")
+chapter_id = "prologue"
+events = Array[ExtResource("1_lrbby")]([SubResource("Resource_foagb"), SubResource("Resource_21i66")])
+next_chapter_id = "prologue2"
+metadata/_custom_type_script = "uid://nsjru0u7n42l"

--- a/scenarios/prologue_cat_saved1_root.tres
+++ b/scenarios/prologue_cat_saved1_root.tres
@@ -1,0 +1,29 @@
+[gd_resource type="Resource" script_class="ScenarioData" load_steps=8 format=3 uid="uid://c6hxm42my7do8"]
+
+[ext_resource type="Script" uid="uid://cl3bhx8qa8d5x" path="res://dialogue_event.gd" id="1_61w23"]
+[ext_resource type="Texture2D" uid="uid://sugcybn04qn2" path="res://images/路地裏3.jpg" id="2_pnxs2"]
+[ext_resource type="AudioStream" uid="uid://dq3ainftkexdg" path="res://BGM/huwa.wav" id="3_h3rc4"]
+[ext_resource type="Texture2D" uid="uid://vycniucbdjsr" path="res://立ち絵/猫立ち絵.png" id="4_t6xgw"]
+[ext_resource type="Script" uid="uid://nsjru0u7n42l" path="res://scenario_date.gd" id="5_imrjk"]
+
+[sub_resource type="Resource" id="Resource_s6ww8"]
+script = ExtResource("1_61w23")
+text = "猫を抱き寄せたと同時に花瓶が猫のいたところに落ちてくる。
+猫は無事だった。"
+character_sprite = ExtResource("4_t6xgw")
+background = ExtResource("2_pnxs2")
+bgm = ExtResource("3_h3rc4")
+shake_screen = true
+metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
+
+[sub_resource type="Resource" id="Resource_61w23"]
+script = ExtResource("1_61w23")
+text = "猫の後を追いかけよう。"
+metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
+
+[resource]
+script = ExtResource("5_imrjk")
+chapter_id = "prologue"
+events = Array[ExtResource("1_61w23")]([SubResource("Resource_s6ww8"), SubResource("Resource_61w23")])
+next_chapter_id = "prologue2"
+metadata/_custom_type_script = "uid://nsjru0u7n42l"


### PR DESCRIPTION
選択肢分岐について実装しました。
＊以前のものは単純に選択肢だけが出て何も小話もなく次の話が出ていました。
＊今回は選択肢を選ぶとシナリオが変化するようにしました。
＊その後はしっかり合流できています。
＊＊注意が必要なのはシナリオが変わると死期が1日分減ることでした。
＊＊そのため章のIDを付与することで死期の1日＝1章の減少を回避しています。

＊＊まだデバッグが足りず、以前実装していたDAY７のシナリオ分岐でエラー吐いてるのでここ直す必要があります。
＊＊ファイル管理用のID（引数の id）」と「シナリオの中身としての章ID（current_data.chapter_id）」の役割が違うことに気づけたので、ちょびっと手直し良さげかも

選択肢に死期予測時間を付与しました。
＊選択後に死期が増減してプレイヤーを怖がらせることができます。
＊＊しかしまだ増減後の死期を死期時間に反映していないので次はここを改修します。
＊＊増減後の死期を加算減算するだけでいいと思うので、ここも少しだけの改修になりそうだといいな(希望観測)