### PR TITLE
凡庸選択肢分岐

### DIFF
--- a/GameDirector.gd
+++ b/GameDirector.gd
@@ -16,8 +16,9 @@ func start_scenario(id: String):
 		printerr("シナリオが見らつかりません: ", id)
 		return
 	
-	# ★追加: Global側の現在IDも更新しておく（セーブ時などに重要）
-	Global.current_chapter_id = id
+	#  Global側の現在IDも更新しておく（セーブ時などに重要）
+	# ファイル名ではなく、.tresファイル内に設定したChapter IDを正とする
+	Global.current_chapter_id = current_data.chapter_id
 	
 	# 2. 下限値の更新
 	Global.current_death_floor = current_data.chapter_death_floor
@@ -40,14 +41,16 @@ func start_scenario(id: String):
 	play_current_event()
 
 # 章ごとの特殊なロジック設定
-func _setup_chapter_logic(id: String):
+func _setup_chapter_logic(_id: String):
 	# プロローグかどうかに関わらず、タイマーの計算自体は動かす
 	Global.is_death_timer_active = true
 	
-	if id != "prologue":
+	var chapter = current_data.chapter_id # 変数に入れておくとスッキリします
+	
+	if chapter != "prologue":
 		Global.current_death_floor = Global.player_death_seconds - Global.SECONDS_PER_DAY
 		
-	if id == "day_7":
+	if chapter == "day_7":
 		Global.is_timer_active = true
 		
 		# --- 追加：ココロネの関連タイマー変数を全て239秒（約4分）に同期する ---
@@ -60,8 +63,9 @@ func _setup_chapter_logic(id: String):
 
 # --- 2. 進行管理 ---
 func play_current_event():
-	# すでにシーン切り替え中なら何もしない
-	if is_changing_scene: return
+	# データがない、または切り替え中なら即座に帰る
+	if current_data == null or is_changing_scene: 
+		return
 	
 	if current_index < current_data.events.size():
 		Global.current_line_index = current_index
@@ -110,6 +114,7 @@ func handle_location_selected(_location_id: String):
 # --- 4. 章終了のロジック（ここが一番重要！） ---
 func _finish_chapter():
 	if is_changing_scene: return
+	is_changing_scene = true # 二重処理防止
 	# 報酬とフラグの処理（元のコードから完全移植）
 	Global.add_flag(current_data.reward_flag)
 	
@@ -130,29 +135,30 @@ func _finish_chapter():
 			# 安全のため call_deferred で実行
 			get_tree().call_deferred("reload_current_scene")
 			
-		ScenarioData.NextAction.DETERMINE_END:
-			if Global.current_chapter_id == "day_7":
-				
-				# ココロネの red (歪み死期) の現在値を取得
-				# ※ Global.get_current_death_time は、red/whiteのうち
-				#   その時表示されている（または優先される）方を返す想定です。
-				var current_red_time = Global.get_current_death_time("Kokorone")
-				
-				var choice_texts = ["運命に抗う（通常エンドへ）", "諦める（バッドエンドへ）"]
-				var disabled_list = []
-				
-				# redの数値が0以下なら、0番目のボタン（運命に抗う）を無効化リストに入れる
-				if current_red_time <= 0:
-					disabled_list.append(0)
-				
-				# 拡張した show_choices を呼び出す
-				stage.show_choices(choice_texts, disabled_list)
-				
-			
 		ScenarioData.NextAction.OPEN_MAP:
 			get_tree().change_scene_to_file("res://map_selection.tscn")
 			
 		ScenarioData.NextAction.GO_TO_TITLE:
+			# ★バッドエンド等からタイトルへ戻る処理
+			# 次に「つづきから」を選んだ時のためにIDだけ設定しておく
+			# バッドエンド1なら次はDay7から、という設定なら変数はそのままでOK
 			if Global.current_chapter_id == "bad_end1":
-				# バッドエンド1からのリトライ処理
 				Global.current_chapter_id = "day_7"
+			
+			# ★実際にタイトルシーンへ切り替える（パスは実際の環境に合わせてください）
+			get_tree().change_scene_to_file("res://title_screen.tscn")
+
+		# --- デバッグ用：ハッピーエンド（または特定の章）が終わったらタイトルへ ---
+		ScenarioData.NextAction.DETERMINE_END:
+			# --- ★ハッピーエンド・真エンド後の処理 ---
+			# chapter_id が "true_end" や "happy_end" ならタイトルへ
+			var c_id = current_data.chapter_id
+			if c_id == "true_end" or c_id == "happy_end":
+				print("エンディング到達。タイトルへ戻ります。")
+				get_tree().change_scene_to_file("res://title_screen.tscn")
+			else:
+				# それ以外（Day 7の末尾など）でここに来た場合
+				# 基本的にDay 7の分岐は .tres の「最後のイベント」に
+				# 選択肢を持たせる設計にしたので、ここは予備の安全装置にします。
+				print("チャプター終了: 次のアクションが未定義です。")
+				get_tree().change_scene_to_file("res://title_screen.tscn")

--- a/dialogue_event.gd
+++ b/dialogue_event.gd
@@ -51,3 +51,13 @@ enum CharID { NONE, KOKORONE, HOMURA, REI, CAT }
 
 ## 選択肢ボタンでの死期表示タイプ　0:Auto, 1:White, 2:Red 
 @export var choice_time_display_types: Array[int] = []
+
+# --- 条件による選択肢の無効化 ---
+## 無効化条件: 対象キャラID ("Kokorone"など)。空文字なら判定なし
+@export var disable_target_chars: Array[String] = []
+
+## 無効化条件: 判定に使う死期 (1: White, 2: Red) ※0や未設定は判定なし
+@export var disable_time_types: Array[int] = []
+
+## 無効化条件: 対象の死期がこの秒数「以下」ならボタンを押せなくする
+@export var disable_thresholds: Array[float] = []

--- a/main_game.gd
+++ b/main_game.gd
@@ -24,8 +24,6 @@ var is_skipping: bool = false
 @onready var pause_menu = $PauseMenu 
 @onready var menu_button = $SystemButtons/MenuButton # 追加したボタン
 
-var day7_resist_button: Button = null
-
 var is_waiting_for_hover: bool = false # ホバー待ち状態のフラグ
 var hover_target_id: String = ""       # 待っている対象のキャラID
 # active_choice_labels を単なるラベル配列から、辞書の配列に変更して詳細なデータを保持させます
@@ -197,7 +195,6 @@ func _update_button_visuals():
 
 # --- 8. 選択肢・特殊演出 ---
 func show_choices(choices: Array, disabled_indices: Array = [], target_id: String = ""):
-	day7_resist_button = null 
 	active_choice_data.clear() # リセット
 	hover_target_id = target_id  # _processで更新するために保存
 	
@@ -241,14 +238,42 @@ func show_choices(choices: Array, disabled_indices: Array = [], target_id: Strin
 				"display_type": display_type # ここに個別の設定が入る！
 			})
 			
-		# ---「運命に抗う」ボタンを後で監視するために変数に入れておく---
-		if choices[i].contains("運命に抗う"):
-			day7_resist_button = btn
+		# ★ここから新規追加：データに基づく無効化判定
+		var is_disabled = false
 		
-		# --- 無効化の判定 ---
-		if i in disabled_indices:
-			btn.disabled = true # ボタンをグレーアウトして押せなくする
-			btn.focus_mode = Control.FOCUS_NONE # 選択もできないようにする
+		# 既存の disabled_indices の判定（念のため残す）
+		if disabled_indices.has(i):
+			is_disabled = true
+			
+		# 新しいデータ駆動の無効化判定
+		if current_event != null:
+			if current_event.disable_target_chars.size() > i:
+				var target_char = current_event.disable_target_chars[i]
+				
+				# ターゲットが設定されていて、Globalに存在する場合
+				if target_char != "" and Global.death_data.has(target_char):
+					var time_type = 0
+					if current_event.disable_time_types.size() > i:
+						time_type = current_event.disable_time_types[i]
+					
+					var threshold = -1.0
+					if current_event.disable_thresholds.size() > i:
+						threshold = current_event.disable_thresholds[i]
+					
+					# タイプが設定(1 or 2)されており、閾値も設定されている場合
+					if time_type > 0 and threshold >= 0.0:
+						var current_val = 0.0
+						if time_type == 1: # White (真実)
+							current_val = Global.death_data[target_char]["white"]
+						elif time_type == 2: # Red (歪み)
+							current_val = Global.death_data[target_char]["red"]
+							
+						# ★現在の死期が閾値「以下」ならボタンを無効化！
+						if current_val <= threshold:
+							is_disabled = true
+
+		# 判定結果をボタンに適用
+		btn.disabled = is_disabled
 		
 		btn.pressed.connect(_on_choice_selected.bind(i))
 		choice_container.add_child(btn)
@@ -280,15 +305,6 @@ func _on_menu_button_pressed() -> void:
 	
 # --- _process 関数を追加（または既存のものに追記） ---
 func _process(_delta):
-	# 監視中のボタンがあり、かつまだ無効化されていない場合
-	if day7_resist_button and not day7_resist_button.disabled:
-		# リアルタイムで死期をチェック
-		if Global.get_current_death_time("Kokorone") <= 0:
-			day7_resist_button.disabled = true
-			day7_resist_button.focus_mode = Control.FOCUS_NONE
-			# ついでにタイマーをここで止めてもいいかもしれません
-			Global.is_timer_active = false
-			print("時間切れにより選択肢が封鎖されました")
 	# ★ホバー待ちチュートリアルの監視
 	if is_waiting_for_hover and hover_target_id != "":
 		# Globalのデータで、対象キャラが「発見済み(discovered)」になったらクリア！
@@ -337,3 +353,29 @@ func _process(_delta):
 						data["label"].add_theme_color_override("font_color", Color(1, 0.3, 0.3)) # 警告の赤
 					_: # Auto または 0
 						data["label"].add_theme_color_override("font_color", Color.WHITE) # 通常の白
+	# --- ★選択肢のリアルタイム無効化監視（汎用版） ---
+	# 選択肢が表示されている間だけ実行
+	if choice_container.visible:
+		var current_event = director.current_data.events[director.current_index]
+		var buttons = choice_container.get_children()
+		
+		for i in range(buttons.size()):
+			var btn = buttons[i] as Button
+			if not btn or btn.disabled: continue # すでに無効ならスルー
+			
+			# current_event の disable 設定をチェック
+			if current_event.disable_target_chars.size() > i:
+				var t_char = current_event.disable_target_chars[i]
+				var t_type = current_event.disable_time_types[i]
+				var threshold = current_event.disable_thresholds[i]
+				
+				if t_char != "" and t_type > 0 and Global.death_data.has(t_char):
+					var current_val = 0.0
+					if t_type == 1: current_val = Global.death_data[t_char]["white"]
+					elif t_type == 2: current_val = Global.death_data[t_char]["red"]
+					
+					# リアルタイムで閾値を下回ったら無効化！
+					if current_val <= threshold:
+						btn.disabled = true
+						btn.focus_mode = Control.FOCUS_NONE
+						print(t_char, " の時間切れによりボタン ", i, " を無効化しました")

--- a/project.godot
+++ b/project.godot
@@ -21,7 +21,7 @@ Global="*res://Global.gd"
 
 [editor]
 
-movie_writer/movie_file="D:/godotdebuc/ScinarioDivide.avi"
+movie_writer/movie_file="D:/godotdebuc/ScinarioDivide2.avi"
 
 [filesystem]
 

--- a/scenarios/bad_end.tres
+++ b/scenarios/bad_end.tres
@@ -1,15 +1,18 @@
-[gd_resource type="Resource" script_class="ScenarioData" load_steps=4 format=3 uid="uid://bo682m04e0q0f"]
+[gd_resource type="Resource" script_class="ScenarioData" load_steps=5 format=3 uid="uid://bo682m04e0q0f"]
 
 [ext_resource type="Script" uid="uid://nsjru0u7n42l" path="res://scenario_date.gd" id="1_tehjq"]
+[ext_resource type="Texture2D" uid="uid://by2c2hvnkcu11" path="res://images/MAP.jpg" id="2_ltm07"]
 [ext_resource type="Script" uid="uid://cl3bhx8qa8d5x" path="res://dialogue_event.gd" id="3_iq15l"]
 
 [sub_resource type="Resource" id="Resource_lpgtv"]
 script = ExtResource("3_iq15l")
 text = "BAD"
+background = ExtResource("2_ltm07")
 metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
 
 [resource]
 script = ExtResource("1_tehjq")
 chapter_id = "bad_end1"
 events = Array[ExtResource("3_iq15l")]([SubResource("Resource_lpgtv")])
+next_action = 2
 metadata/_custom_type_script = "uid://nsjru0u7n42l"

--- a/scenarios/day_7.tres
+++ b/scenarios/day_7.tres
@@ -61,6 +61,13 @@ text = "死は目の前にある。
 "
 character_sprite = ExtResource("4_trxda")
 background = ExtResource("3_ya636")
+target_char_id = "Kokorone"
+choices = Array[String](["運命に抗う", "諦める"])
+choice_next_scenario_ids = Array[String](["happy_end1", "bad_end1"])
+choice_time_display_types = Array[int]([2, 2])
+disable_target_chars = Array[String](["Kokorone", ""])
+disable_time_types = Array[int]([2, 0])
+disable_thresholds = Array[float]([0.0, -1.0])
 metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
 
 [resource]


### PR DESCRIPTION
DAY7の選択肢分岐を凡庸化しました。
＊以前の選択肢分岐は特定のシナリオの最期に選択肢分岐する形だったので、コードも長く複雑になっていました。
＊＊そこでtresデータを拡張して、シナリオ分岐できるようにしました。
＊＊死期がある数値を下回った場合選択できないという条件付けができるようになっています。

実装内容

＊死期数値による条件付き選択肢の実装。
＊＊この式の数値は死期改変前のWhiteと死期改変後のredの数値どちらでも行けるようにしています。

＊シナリオファイルのidの参照元変更
＊＊「ファイル管理用のID（引数の id）」と「シナリオの中身としての章ID（current_data.chapter_id）」の違いみたいなやつ
＊＊猫の死期不動化の解消はこれでなんか治ったのでラッキー

＊古いロジックの消去
＊＊DAY7用の分岐などの色々が不要になったので消去してます。