### PR TITLE
場面切り替えインク

### DIFF
--- a/GameDirector.gd
+++ b/GameDirector.gd
@@ -13,7 +13,7 @@ func start_scenario(id: String):
 	# 1. データのロード
 	current_data = Global.get_scenario_resource(id)
 	if current_data == null:
-		printerr("シナリオが見らつかりません: ", id)
+		printerr("シナリオが見つかりません: ", id)
 		return
 	
 	#  Global側の現在IDも更新しておく（セーブ時などに重要）
@@ -127,12 +127,18 @@ func _finish_chapter():
 	if not Global.is_part2 and current_data.chapter_id != "prologue" and current_data.chapter_id != "day_7":
 		Global.advance_all_timers(Global.SECONDS_PER_DAY)
 		
+	# シーン遷移の前に水彩フェードインで画面を覆う
+	# await で完全に塗りつぶされるまで待ってからシーンを切り替える
+	await stage.fade_in_for_scene_change(0.6)
+	
 	# 次の行動の判定
 	match current_data.next_action:
 		ScenarioData.NextAction.AUTO_NEXT:
 			Global.current_chapter_id = current_data.next_chapter_id
 			Global.current_line_index = 0
 			# 安全のため call_deferred で実行
+			# reload_current_scene はフレーム末尾に実行されるため
+			# call_deferred で安全にキューイングする
 			get_tree().call_deferred("reload_current_scene")
 			
 		ScenarioData.NextAction.OPEN_MAP:

--- a/Global.gd
+++ b/Global.gd
@@ -67,6 +67,8 @@ const SYSTEM_SAVE_PATH = "user://system.dat"
 
 # 追加
 var is_hovering_proxy: bool = false
+# 場面切り替え
+var start_with_transition: bool = false
 
 # --- 便利関数（計算・判定用） ---
 # 現在表示すべき「死期」の数値を返す

--- a/dialogue_event.gd
+++ b/dialogue_event.gd
@@ -5,6 +5,18 @@ class_name DialogueEvent
 # 表示位置の定義
 enum CharacterPos { NONE, LEFT, RIGHT, CENTER }
 
+# 背景トランジションの種類
+# エディタのインスペクターで各セリフごとに選択できる
+enum BgTransition {
+	## 章が変わり背景も変わる（最初のイベント）
+	## 同じ章内で背景を切り替えたい
+	AUTO,       # 【デフォルト】背景が変わる時だけ水彩トランジション。章移行直後は重複しないよう自動スキップ。
+	## 背景を切り替えるがトランジション不要
+	NONE,       # トランジションなし。背景を即座に差し替える。
+	## 同じ背景のまま演出として水彩を挟みたい
+	WATERCOLOR  # 背景が変わらなくても強制的に水彩トランジションを実行する。演出上の強調に使う。
+}
+
 @export_group("Text")
 @export var character_name: String = ""       # キャラ名（空なら名前枠非表示）
 @export_multiline var text: String = ""       # セリフ本文
@@ -14,6 +26,7 @@ enum CharacterPos { NONE, LEFT, RIGHT, CENTER }
 @export var character_sprite: Texture2D       # 立ち絵
 @export var char_expression: String = ""      # (任意) 表情の識別子（"angry", "smile"など）
 @export var background: Texture2D             # 背景（変更時のみセット）
+@export var bg_transition: BgTransition = BgTransition.AUTO #この行の背景トランジションの種類。AUTOで通常の自動判定。
 @export var base_scale: float = 1.0          # 素材本来の大きさを調整する用
 @export var character_scale: float = 1.0      # 1.0 が標準。1.2なら20%拡大、0.8なら20%縮小。
 @export var timer_offset: Vector2 = Vector2() # タイマーの表示位置微調整
@@ -30,7 +43,7 @@ enum CharacterPos { NONE, LEFT, RIGHT, CENTER }
 ## trueにすると、このセリフの時にクリック進行を止め、対象キャラへのマウスオーバーを待つ
 @export var require_hover_tutorial: bool = false
 ## チュートリアルや選択肢、死期表示で対象とするキャラID。
-## ★バグ防止のため、Global.death_dataのキー（"Player", "Kokorone", "Homura", "Rei", "Cat"）と完全に一致させてください。
+## バグ防止のため、Global.death_dataのキー（"Player", "Kokorone", "Homura", "Rei", "Cat"）と完全に一致させてください。
 @export var target_char_id: String = ""
 
 @export_group("Choices & Branching")

--- a/main_game.gd
+++ b/main_game.gd
@@ -13,6 +13,8 @@ extends Control
 @onready var backlog_canvas = $BacklogCanvas
 @onready var log_list = $BacklogCanvas/Panel/ScrollContainer/LogList
 
+@onready var fade_overlay = $TransitionLayer/FadeOverLay
+
 # --- 2. システム変数 ---
 var is_auto: bool = false
 var is_skipping: bool = false
@@ -29,8 +31,13 @@ var hover_target_id: String = ""       # 待っている対象のキャラID
 # active_choice_labels を単なるラベル配列から、辞書の配列に変更して詳細なデータを保持させます
 var active_choice_data: Array[Dictionary] = []
 
+# トランジション実行中フラグ（二重起動・誤クリック防止）
+var is_transitioning: bool = false
+
 # チュートリアル用のメッセージラベルを動的に作る（シーンに直接配置してもOKです）
 var tutorial_label: Label
+
+
 
 # --- 3. 初期化処理 ---
 func _ready():
@@ -49,16 +56,152 @@ func _ready():
 	if Global.is_loading_process:
 		_restore_visuals_from_save()
 		Global.is_loading_process = false 
+		
 	# --- 3. 最後にシナリオを開始する ---
+	# 章移行後フラグの確認と二重トランジション防止
+	# start_scenario() より前にフラグを読んで is_transitioning を立てておく。
+	# こうすることで、start_scenario() 内から呼ばれる render_event() が
+	# bg_transition=AUTO のトランジションを自動スキップし、二重にならない。
+	var coming_from_chapter_change = Global.start_with_transition
+	if coming_from_chapter_change:
+		Global.start_with_transition = false
+		is_transitioning = true  # render_event のAUTO判定をブロック
+		# オーバーレイを「塗りつぶし済み」状態でセットしておく
+		var mat := fade_overlay.material as ShaderMaterial
+		if mat:
+			mat.set_shader_parameter("progress", 1.0)
+		fade_overlay.show()
 	# これを呼ぶと render_event が動くので、必ず一番最後に書く
+	# シナリオ開始（render_event が呼ばれる。is_transitioning=true なら AUTO はスキップ）
 	director.start_scenario(Global.current_chapter_id)
 	
+
 func _restore_visuals_from_save():
 	if Global.current_bg_path != "":
 		background.texture = load(Global.current_bg_path)
 	if Global.current_bgm_path != "":
 		bgm_player.stream = load(Global.current_bgm_path)
 		bgm_player.play()
+
+# ==============================================================
+# トランジション関数群
+# ==============================================================
+
+## フェードアウト共通処理
+## transition_do と _apply_background（章移行直後）の両方で使う
+func _fade_out_overlay(duration: float = 0.6) -> void:
+	# タメ：テクスチャ反映の1フレーム遅れを吸収する
+	await get_tree().create_timer(0.08).timeout
+ 
+	if not fade_overlay:
+		is_transitioning = false
+		return
+ 
+	var mat := fade_overlay.material as ShaderMaterial
+	if mat:
+		var tween = create_tween()
+		tween.tween_property(mat, "shader_parameter/progress", 1.0, duration)
+		await tween.finished
+ 
+	fade_overlay.hide()
+	is_transitioning = false
+ 
+ 
+## 背景切り替え用：水彩で覆う → callback実行 → _fade_out_overlay()
+## render_event() → _apply_background() から await で呼ばれる
+func transition_do(callback: Callable, duration: float = 1.0) -> void:
+	if not fade_overlay:
+		callback.call()
+		return
+ 
+	var mat := fade_overlay.material as ShaderMaterial
+	if not mat:
+		callback.call()
+		return
+ 
+	is_transitioning = true
+	fade_overlay.show()
+ 
+	# フェードイン（水彩が画面を塗りつぶす）
+	var tween = create_tween()
+	tween.tween_property(mat, "shader_parameter/progress", 0.0, duration * 0.45)
+	await tween.finished
+ 
+	# 完全に隠れた瞬間に背景を差し替える
+	callback.call()
+ 
+	# フェードアウト（共通処理）
+	await _fade_out_overlay(duration * 0.45)
+ 
+ 
+## 章移行用（フェードインのみ）：画面を水彩で覆い、シーン遷移を渡す
+## GameDirector._finish_chapter() から await で呼ばれる
+## フェードアウトは新シーンの _apply_background() が担当する
+func fade_in_for_scene_change(duration: float = 0.6) -> void:
+	if not fade_overlay: return
+ 
+	var mat := fade_overlay.material as ShaderMaterial
+	if not mat: return
+ 
+	is_transitioning = true
+	fade_overlay.show()
+ 
+	var tween = create_tween()
+	tween.tween_property(mat, "shader_parameter/progress", 0.0, duration)
+	await tween.finished
+ 
+	# 次のシーンに「覆われた状態から始まる」ことを伝える
+	Global.start_with_transition = true
+ 
+# ==============================================================
+# 背景トランジションの振り分けロジック（render_event から呼ぶ）
+# ==============================================================
+ 
+## ev.bg_transition の設定に従って背景を切り替える。
+## 章移行直後（is_transitioning=true）は fade-out のみ担当する。
+## 戻り値なし。await で呼ぶこと。
+func _apply_background(ev: DialogueEvent) -> void:
+	# 背景指定がない場合でも、章移行直後ならフェードアウトだけ担当する
+	if not ev.background:
+		if is_transitioning:
+			await _fade_out_overlay(0.6)
+		return
+ 
+	var do_change = func():
+		background.texture = ev.background
+		Global.current_bg_path = ev.background.resource_path
+ 
+	match ev.bg_transition:
+ 
+		DialogueEvent.BgTransition.NONE:
+			# トランジションなし：即差し替え
+			# 章移行直後でもフェードアウトは行わない（即見せる）
+			do_change.call()
+			if is_transitioning:
+				# 覆われたままなのでフェードアウトだけする
+				await _fade_out_overlay(0.6)
+ 
+		DialogueEvent.BgTransition.WATERCOLOR:
+			if is_transitioning:
+				# 章移行直後：すでに覆われているので bg変更 → フェードアウトのみ
+				do_change.call()
+				await _fade_out_overlay(0.6)
+			else:
+				# 通常：フェードイン → bg変更 → フェードアウト
+				await transition_do(do_change, 1.0)
+ 
+		DialogueEvent.BgTransition.AUTO, _:
+			if is_transitioning:
+				# 章移行直後：すでに覆われているので bg変更 → フェードアウトのみ
+				do_change.call()
+				await _fade_out_overlay(0.6)
+			elif ev.background != background.texture:
+				# 通常：背景が変わるときだけトランジション
+				await transition_do(do_change, 1.0)
+			else:
+				# 同じ背景：何もしない
+				do_change.call()
+ 
 
 func _check_button_disabled(ev: DialogueEvent, index: int) -> bool:
 	if ev.disable_target_chars.size() <= index: return false
@@ -79,20 +222,20 @@ func _check_button_disabled(ev: DialogueEvent, index: int) -> bool:
 
 # --- 4. 演出の実行（監督から命令される） ---
 func render_event(ev: DialogueEvent):
-	# 背景・BGMの更新
-	if ev.background:
-		background.texture = ev.background
-		Global.current_bg_path = ev.background.resource_path
-		
+	# BGM・SEは背景トランジション前に先行して変える
+	# （音は視覚より早く変わることで、場面転換の予感を演出できる）
 	if ev.bgm and bgm_player.stream != ev.bgm:
 		bgm_player.stream = ev.bgm
 		bgm_player.play()
 		Global.current_bgm_path = ev.bgm.resource_path
-		
+ 
 	if ev.se:
 		se_player.stream = ev.se
 		se_player.play()
-
+	
+	# 背景の切り替え（BgTransition設定に従って振り分け）
+	await _apply_background(ev)
+	
 	# バックログ・立ち絵更新・画面揺れ
 	Global.add_to_backlog(ev.character_name, ev.text)
 	%CharacterContainer.update_portraits(ev)
@@ -120,10 +263,12 @@ func render_event(ev: DialogueEvent):
 		message_window.skip_typing()
 		get_tree().create_timer(0.05).timeout.connect(advance_line)
 
+
 # --- 5. 進行管理と入力 ---
 func advance_line():
 	# 選択肢が出ている時や、ホバー待ちの時は勝手に進ませない
-	if choice_container.visible or is_waiting_for_hover: 
+	# トランジション中も進行をブロックする
+	if choice_container.visible or is_waiting_for_hover or is_transitioning:
 		return
 	director.next_line()
 
@@ -133,7 +278,8 @@ func _unhandled_input(event):
 	if backlog_canvas and backlog_canvas.visible: return # 履歴を見ている
 	if choice_container.visible: return # 選択肢を選んでいる
 	if is_waiting_for_hover: return # チュートリアル中
-
+	if is_transitioning: return # トランジション中はクリック・キー入力を無視する
+	
 	# B. システム操作
 	if event.is_action_pressed("ui_auto"): 
 		toggle_auto()

--- a/main_game.tscn
+++ b/main_game.tscn
@@ -1,4 +1,4 @@
-[gd_scene load_steps=22 format=3 uid="uid://cllpcuaeq424j"]
+[gd_scene load_steps=27 format=3 uid="uid://cllpcuaeq424j"]
 
 [ext_resource type="Script" uid="uid://b7scfg1k3ox20" path="res://main_game.gd" id="1_1oj5k"]
 [ext_resource type="Script" uid="uid://cspbt4kiho02r" path="res://GameDirector.gd" id="2_4srsv"]
@@ -12,9 +12,9 @@
 [ext_resource type="Shader" uid="uid://b1ebrc8ut2kq2" path="res://main_game.gdshader" id="5_2pltu"]
 [ext_resource type="Texture2D" uid="uid://devwgvlu5hciy" path="res://images/紙.png" id="5_krmtw"]
 [ext_resource type="Texture2D" uid="uid://b47cr6rft7vqt" path="res://water_noise.tres" id="6_f52ns"]
-[ext_resource type="Texture2D" uid="uid://0aosbm30laop" path="res://images/道路.png" id="6_jgkyn"]
 [ext_resource type="Shader" uid="uid://cp5y0asu2h6xg" path="res://water_ripple.gdshader" id="9_qpaub"]
 [ext_resource type="Script" uid="uid://6scip3yxyq4e" path="res://ripple_layer.gd" id="10_an1vu"]
+[ext_resource type="Shader" uid="uid://cj8etpfl5pe5v" path="res://watercolor_transition.gdshader" id="13_an1vu"]
 
 [sub_resource type="FastNoiseLite" id="FastNoiseLite_krmtw"]
 frequency = 0.02
@@ -44,6 +44,34 @@ shader_parameter/time_decay = 1.6
 shader_parameter/max_age = 2.8
 
 [sub_resource type="RectangleShape2D" id="RectangleShape2D_krmtw"]
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_borgi"]
+frequency = 0.0121
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_ih6an"]
+noise = SubResource("FastNoiseLite_borgi")
+seamless = true
+
+[sub_resource type="FastNoiseLite" id="FastNoiseLite_umrn2"]
+noise_type = 2
+frequency = 0.07
+
+[sub_resource type="NoiseTexture2D" id="NoiseTexture2D_2i4tw"]
+noise = SubResource("FastNoiseLite_umrn2")
+seamless = true
+
+[sub_resource type="ShaderMaterial" id="ShaderMaterial_euc45"]
+shader = ExtResource("13_an1vu")
+shader_parameter/base_noise = SubResource("NoiseTexture2D_ih6an")
+shader_parameter/detail_noise = SubResource("NoiseTexture2D_2i4tw")
+shader_parameter/progress = 1.0
+shader_parameter/smoothness = 0.08
+shader_parameter/ink_color = Color(0, 0.25197893, 0.4002653, 1)
+shader_parameter/edge_color = Color(0.55, 0.65, 0.75, 1)
+shader_parameter/edge_intensity = 1.2
+shader_parameter/noise_blend = 0.65
+shader_parameter/flow_speed = 0.12
+shader_parameter/noise_scale = 1.5400000494
 
 [sub_resource type="ShaderMaterial" id="ShaderMaterial_l5ukw"]
 shader = ExtResource("5_2pltu")
@@ -119,7 +147,7 @@ anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
 mouse_filter = 2
-texture = ExtResource("6_jgkyn")
+texture = ExtResource("3_02kkc")
 expand_mode = 1
 stretch_mode = 6
 
@@ -248,13 +276,20 @@ text = "▼"
 horizontal_alignment = 2
 vertical_alignment = 2
 
-[node name="FadeOverLay" type="ColorRect" parent="."]
+[node name="TransitionLayer" type="CanvasLayer" parent="."]
+layer = 11
+
+[node name="FadeOverLay" type="ColorRect" parent="TransitionLayer"]
 visible = false
-layout_mode = 0
-offset_right = 1168.0
-offset_bottom = 669.0
+material = SubResource("ShaderMaterial_euc45")
+anchors_preset = 15
+anchor_right = 1.0
+anchor_bottom = 1.0
+grow_horizontal = 2
+grow_vertical = 2
 mouse_filter = 2
 color = Color(0, 0, 0, 1)
+metadata/_edit_group_ = true
 
 [node name="PauseMenu" parent="." instance=ExtResource("2_yx7mw")]
 layer = 10

--- a/scenarios/prologue.tres
+++ b/scenarios/prologue.tres
@@ -14,6 +14,7 @@ text = "死期が見えるようになった。
 時間までは書いていない。
 でもその日に必ず死は訪れる。"
 background = ExtResource("1_4mfdp")
+bg_transition = 1
 bgm = ExtResource("2_l5nuy")
 metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
 
@@ -21,6 +22,7 @@ metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
 script = ExtResource("1_phd66")
 text = "いつから見えるようになったかは覚えていない。
 最初はただ数字が頭上に浮かんでいるだけだと思っていた。"
+bg_transition = 1
 metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"
 
 [sub_resource type="Resource" id="Resource_bs7l3"]
@@ -69,6 +71,7 @@ text = "この猫も同じく頭上の数字が近づいていた。
 まるで自分の死期を眺めるように中空をじっと眺めていた猫はとても年老いていた。"
 character_sprite = SubResource("CompressedTexture2D_8x785")
 background = ExtResource("4_bs7l3")
+bg_transition = 2
 require_hover_tutorial = true
 target_char_id = "Cat"
 metadata/_custom_type_script = "uid://cl3bhx8qa8d5x"

--- a/watercolor_transition.gdshader
+++ b/watercolor_transition.gdshader
@@ -1,0 +1,114 @@
+// watercolor_transition.gdshader
+// 水彩絵の具が画面を塗りつぶしていくようなトランジション演出
+// FadeOverLay (ColorRect) に ShaderMaterial として適用する
+shader_type canvas_item;
+
+// ============================================================
+// ノイズテクスチャ（Godotエディタで2つ用意してセットする）
+// ============================================================
+// [base_noise の設定推奨値]
+//   Noise Type  : Simplex Smooth
+//   Frequency   : 0.005 〜 0.01  （大きなモヤモヤ）
+//   Fractal Type: FBM
+//   Seamless    : ON
+uniform sampler2D base_noise : repeat_enable;
+
+// [detail_noise の設定推奨値]
+//   Noise Type        : Cellular
+//   Frequency         : 0.05 〜 0.1  （紙のザラザラ感）
+//   Fractal Type      : FBM
+//   Cellular Return   : Distance
+//   Seamless          : ON
+uniform sampler2D detail_noise : repeat_enable;
+
+// ============================================================
+// トランジション制御パラメータ
+// ============================================================
+
+// 進行度（GDScriptのTweenでここを 0.0 → 1.0 に動かす）
+// 0.0 = 完全に透明（元の画面が見える）
+// 1.0 = 完全に塗りつぶし（水彩色で画面が覆われる）
+uniform float progress : hint_range(0.0, 1.0) = 0.0;
+
+// 境界のぼかし幅（大きいほどじわっとした滲みになる）
+uniform float smoothness : hint_range(0.01, 0.4) = 0.08;
+
+// ============================================================
+// 見た目のパラメータ
+// ============================================================
+
+// 水彩絵の具の色（画面を塗りつぶす色）
+// 白っぽい紙の色や、絵柄に合わせた色に変えてOK
+uniform vec4 ink_color : source_color = vec4(0.96, 0.94, 0.88, 1.0);
+
+// 絵の具のフチ（溜まり）の色
+// 水彩特有の「乾いた縁」の濃い部分を表現する
+uniform vec4 edge_color : source_color = vec4(0.55, 0.65, 0.75, 1.0);
+
+// フチの濃さ（0.0でフチなし、2.0で濃い縁）
+uniform float edge_intensity : hint_range(0.0, 3.0) = 1.2;
+
+// ベースノイズとディテールノイズの合成比率
+// 0.0 = ディテールのみ / 1.0 = ベースのみ
+uniform float noise_blend : hint_range(0.0, 1.0) = 0.65;
+
+// ============================================================
+// 内部アニメーション（オプション）
+// ============================================================
+
+// 塗りつぶし中にゆらゆらと動くアニメーション速度
+// 0.0 にすると完全に静止した絵になる
+uniform float flow_speed : hint_range(0.0, 1.0) = 0.5;
+
+// UVのタイリング倍率（1.0で画面ぴったり、2.0で2倍の密度）
+uniform float noise_scale : hint_range(0.5, 4.0) = 2.0;
+
+void fragment() {
+	// --------------------------------------------------------
+	// 1. ノイズ合成（水彩のシミ形状を決定する）
+	// --------------------------------------------------------
+
+	// 時間経過でノイズをゆっくり流す（生き生きとした絵の具感）
+	vec2 flow_offset = vec2(TIME * flow_speed * 0.03, TIME * flow_speed * 0.02);
+	vec2 scaled_uv = UV * noise_scale;
+
+	float b = texture(base_noise,   scaled_uv + flow_offset).r;
+	float d = texture(detail_noise, scaled_uv - flow_offset * 0.5).r;
+
+	// ベース（大きなモヤモヤ）とディテール（紙のザラザラ）を合成
+	float combined = mix(d, b, noise_blend);
+
+	// --------------------------------------------------------
+	// 2. マスク計算（どこまで塗られているかを決める）
+	// --------------------------------------------------------
+
+	// smoothstep で境界をぼかし、水彩のじわっとした滲みを再現
+	float mask = smoothstep(progress - smoothness, progress + smoothness, combined);
+
+	// --------------------------------------------------------
+	// 3. 水彩フチ（絵の具の溜まり）を計算する
+	// --------------------------------------------------------
+	// トランジション境界のごく狭い範囲だけを検出して色を濃くする
+
+	float edge_low  = smoothstep(progress - smoothness,       progress,                combined);
+	float edge_high = smoothstep(progress,                    progress + smoothness,    combined);
+	float edge_band = edge_low - edge_high; // 境界部分だけが 1.0 になる帯
+
+	// --------------------------------------------------------
+	// 4. 最終カラーの合成
+	// --------------------------------------------------------
+
+	// 水彩色のベースにフチ色を乗せる
+	vec3 painted_rgb = mix(ink_color.rgb, edge_color.rgb, edge_band * edge_intensity);
+
+	// mask に基づいてアルファを決定
+	// mask=0 → 透明（元の画面が透けて見える）
+	// mask=1 → 不透明（水彩色で塗られた）
+	float final_alpha = mask;
+
+// progress が完全に 0.0（密封）になった時のドット抜け・ちらつき防止
+	// progressが 0.05 から 0.0 に近づくにつれて、強制的に alpha を 1.0 (完全不透明) にする
+	final_alpha = mix(1.0, final_alpha, smoothstep(0.0, 0.05, progress));
+
+	COLOR = vec4(painted_rgb, final_alpha);
+}

--- a/watercolor_transition.gdshader.uid
+++ b/watercolor_transition.gdshader.uid
@@ -1,0 +1,1 @@
+uid://cj8etpfl5pe5v


### PR DESCRIPTION
＊tresデータにおけるDialogueEvent内の項目、BG Transitionを追加しました。
＊使い分けは次の通り、
章移行直後（is_transitioning=true）、背景あり　　背景即差し替え → フェードアウトのみ
章移行直後（is_transitioning=true）、背景なし　　フェードアウトのみ（背景変更なし）
通常時、AUTO、背景が変わる　　　　　　　　　フェードイン → 背景差し替え → フェードアウト
通常時、NONE　　　　　　　　　　　　　　　　即差し替え（トランジションなし）
通常時、WATERCOLOR　　　　　　　　　　　　  背景が同じでも強制トランジション

＊＊背景変更するとトランジッション入るようになったのですが、まだ種類が足りないので種類の追加を考えています。
＊＊今のところ強制トランジッション(WATERCOLOR)が一番スムーズな画面遷移な気がしてます。